### PR TITLE
Sometimes Annual stats are not available therefore empty strings are …

### DIFF
--- a/pyhydroquebec/__main__.py
+++ b/pyhydroquebec/__main__.py
@@ -77,11 +77,11 @@ Annual Total
 
 Start date:             {d[annual_date_start]}
 End date:               {d[annual_date_end]}
-Total bill:             {d[annual_total_bill]:.2f} $
-Mean daily bill:        {d[annual_mean_daily_bill]:.2f} $
-Total consumption:      {d[annual_total_consumption]:.2f} kWh
-Mean dailyconsumption:  {d[annual_mean_daily_consumption]:.2f} kWh
-kWh price:              {d[annual_kwh_price_cent]:0.2f} ¢
+Total bill:             {d[annual_total_bill]} $
+Mean daily bill:        {d[annual_mean_daily_bill]} $
+Total consumption:      {d[annual_total_consumption]} kWh
+Mean dailyconsumption:  {d[annual_mean_daily_consumption]} kWh
+kWh price:              {d[annual_kwh_price_cent]} ¢
 """)
         print(output3.format(d=data))
 

--- a/pyhydroquebec/client.py
+++ b/pyhydroquebec/client.py
@@ -14,7 +14,7 @@ from dateutil import tz
 #Always get the time using HydroQuebec Local Time
 HQ_TIMEZONE = tz.gettz('America/Montreal')
 
-REQUESTS_TIMEOUT = 15
+REQUESTS_TIMEOUT = 30
 
 HOST = "https://www.hydroquebec.com"
 HOME_URL = "{}/portail/web/clientele/authentification".format(HOST)


### PR DESCRIPTION
Since the print assumes the value would be a floating number, therefore it was giving type errors. Hence I remove the floating point conversion to avoid that. 

Secondly, Updated the timeout value to be 30 seconds.