### PR TITLE
Fix a crash when fetching annual data without a previous year

### DIFF
--- a/pyhydroquebec/client.py
+++ b/pyhydroquebec/client.py
@@ -237,4 +237,5 @@ class HydroQuebecClient():
 
     async def close_session(self):
         """Close current session."""
-        await self._session.close()
+        if self._session is not None:
+            await self._session.close()

--- a/pyhydroquebec/customer.py
+++ b/pyhydroquebec/customer.py
@@ -116,7 +116,9 @@ class Customer():
 
         for key, raw_key in ANNUAL_MAP:
             self._current_annual_data[key] = json_res['courant'][raw_key]
-            self._compare_annual_data[key] = json_res['compare'][raw_key]
+
+            if 'compare' in json_res:
+                self._compare_annual_data[key] = json_res['compare'][raw_key]
 
     @property
     def current_annual_data(self):


### PR DESCRIPTION
This PR fix a NPE when fetching annual data on a contract without previous year data (new contract or a move). It also fix a NPE when the CLI failed to authenticate and try to clean a non-existent session.

**Steps to reproduce :**
 - With a contract without previous data, invoke the cli with the following options :
    - `-u xxx-user--xxx -p xxx-password-xxx -c xxx-14123-xxx -L INFO`
    - it could also be reproduce with the `-H` option
- Last logged line should contain *Fetching annual data*
- An out of context *'compare'* message should be printed

**Expected behavior :** The CLI should not crash and report the current year data