### PR TITLE
WIP: Consolidate app entry for both mqtt and cli, better docker doc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,6 @@ env:
 
 upload:
 	env/bin/python setup.py sdist upload -r pypi
-
-
-docker-mqtt:
-	docker build -f docker/mqtt/Dockerfile -t pyhydroquebec:mqtt-3.0 .
-
-docker-cli:
+	
+docker:
 	docker build -f docker/cli/Dockerfile -t pyhydroquebec:3.0 .

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Print your current data
 List your current contracts
 
 ::
-config.yaml PYHQ_OUTPUT=MQTT registry.gitlab.com/ttblt-hass/pyhydroquebec:master
+
     pyhydroquebec -u MYACCOUNT -p MYPASSWORD -l
 
 
@@ -72,35 +72,26 @@ Edit config.yaml
 
 ::
 
-    MQTT_USERNAME=mqtt_username MQTT_PASSWORD=mqtt_password MQTT_HOST=mqtt_ip MQTT_PORT=mqtt_port CONFIG=config.yaml mqtt_pyhydroquebec
-
-
-With Docker
-
-::
-
-    MQTT_USERNAME=mqtt_username MQTT_PASSWORD=mqtt_password MQTT_HOST=mqtt_ip MQTT_PORT=mqtt_port CONFIG=config.yaml PYHQ_OUTPUT=MQTT registry.gitlab.com/ttblt-hass/pyhydroquebec:master
-
-
+    MQTT_USERNAME=mqtt_username MQTT_PASSWORD=mqtt_password MQTT_HOST=mqtt_ip MQTT_PORT=mqtt_port PYHQ_CONFIG=config.yaml pyhydroquebec -m
 
 Docker
 ######
 
 Docker image list: https://gitlab.com/ttblt-hass/pyhydroquebec/container_registry
 
-::
+Docker CLI Mode
+""""""""""""""""
 
-    docker run -e PYHQ_USER=*** -e PYHQ_PASSWORD=*** registry.gitlab.com/ttblt-hass/pyhydroquebec:master
+    ::
 
-Docker variables
-"""""""""
+        docker run -e PYHQ_USER=*** -e PYHQ_OUTPUT=mqtt -v config.yaml:/etc/pyhydroquebec/pyhydroquebec.yaml registry.gitlab.com/ttblt-hass/pyhydroquebec:master
 
     **PYHQ_USER** - Required
         `-e PYHQ_USER=myusername`
-    
+
     **PYHQ_PASSWORD** - Required
         `-e PYHQ_PASSWORD=mypassword`    
-    
+
     **PYHQ_OUTPUT**
 
     - `-e PYHQ_OUTPUT=TEXT` - Default
@@ -112,6 +103,27 @@ Docker variables
 
         `-e PYHQ_CONTRACT=332211223`
 
+Docker MQTT Mode
+""""""""""""""""
+
+    ::
+
+        docker run -e MQTT_USERNAME=mqtt_username -e MQTT_PASSWORD=mqtt_password -e MQTT_HOST=127.0.0.1 -e MQTT_PORT=1883 -e PYHQ_OUTPUT=mqtt -v config.yaml:/etc/pyhydroquebec/pyhydroquebec.yaml registry.gitlab.com/ttblt-hass/pyhydroquebec:master
+
+    **MQTT_USERNAME** - Required
+        `-e MQTT_USERNAME=myusername`
+
+    **MQTT_PASSWORD** - Required
+        `-e MQTT_PASSWORD=mypassword`    
+
+    **MQTT_HOST** - Required
+        `-e MQTT_HOST=127.0.0.1`    
+
+    **MQTT_PORT** - Required
+        `-e MQTT_PORT=1883`    
+
+    **PYHQ_CONFIG** - Optional
+        `-e PYHQ_CONFIG=/etc/pyhydroquebec/pyhydroquebec.yaml` 
 
 Dev env
 #######

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,14 +36,14 @@ then
 fi
 
 # Config
-if [ -z "$CONFIG" ]
+if [ -z "$PYHQ_CONFIG" ]
 then
-    export CONFIG="/etc/pyhydroquebec/pyhydroquebec.yaml"
+    export PYHQ_CONFIG="/etc/pyhydroquebec/pyhydroquebec.yaml"
 fi
 
 if [ "$PYHQ_OUTPUT" == "MQTT" ]
 then
-    mqtt_pyhydroquebec
+    pyhydroquebec -m
 else
     pyhydroquebec -u $PYHQ_USER -p $PYHQ_PASSWORD $PYHQ_CMD_OUTPUT $PYHQ_CMD_CONTRACT
 fi

--- a/kubernetes/mqtt_sensor_pyhydroquebec.yaml
+++ b/kubernetes/mqtt_sensor_pyhydroquebec.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: mqtt-sensor-hydroquebec
-        image: registry.gitlab.com/ttblt-hass/pyhydroquebec/mqtt:latest
+        image: registry.gitlab.com/ttblt-hass/pyhydroquebec:master
         volumeMounts:
         - name: pyhydroquebec-config
           mountPath: /etc/pyhydroquebec.yaml
@@ -50,7 +50,7 @@ spec:
           value: hydroquebec
         - name: LOG_LEVEL
           value: INFO
-        - name: CONFIG
+        - name: PYHQ_CONFIG
           value: /etc/pyhydroquebec.yaml
       volumes:
       - name: pyhydroquebec-config

--- a/pyhydroquebec/mqtt_daemon.py
+++ b/pyhydroquebec/mqtt_daemon.py
@@ -33,13 +33,14 @@ class MqttHydroQuebec(mqtt_hass_base.MqttDevice):
     timeout = None
     frequency = None
 
-    def __init__(self):
+    def __init__(self, mqtt_file):
         """Create new MqttHydroQuebec Object."""
         mqtt_hass_base.MqttDevice.__init__(self, "mqtt-hydroquebec")
+        self.mqtt_file = mqtt_file
 
     def read_config(self):
         """Read config from yaml file."""
-        with open(os.environ['CONFIG']) as fhc:
+        with open(self.mqtt_file) as fhc:
             self.config = load(fhc, Loader=Loader)
         self.timeout = self.config.get('timeout', 30)
         # 6 hours

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(name='pyhydroquebec',
       entry_points={
           'console_scripts': [
               'pyhydroquebec = pyhydroquebec.__main__:main',
-              'mqtt_pyhydroquebec = pyhydroquebec.__main__:mqtt_daemon'
           ]
       },
       license='Apache 2.0',


### PR DESCRIPTION
Hi,

I'm proposing that we consolidate both MQTT and CLI functions into the same app entry. I think this would mean simpler infrastructure around this library (one docker, one executable, multiple config)

I've updated the doc to be clearer of the two mode (CLI output and MQTT deamon) and fixed a couple of typo.

I'm aware that I'm proposing some breaking changes, but I think those are for the best.
* Changing the config variable from CONFIG to PYHQ_CONFIG. CONFIG is a little too generic and may cause collisions issue with other software.
* Removing `mqtt_pyhydroquebec` executable alias. To consolidate help and variables check in the main file.

I would have to do a little more testing to get this up and running, but would like your feedback before I continue.