### PR TITLE
Enable --json option

### DIFF
--- a/pyhydroquebec/__main__.py
+++ b/pyhydroquebec/__main__.py
@@ -163,7 +163,7 @@ def main():
     elif args.influxdb:
         output_influx(results[0])
     elif args.json or args.detailled_energy:
-        output_json(results[0])
+        output_json(results[0], args.hourly)
     else:
         output_text(results[0], args.hourly)
     return 0

--- a/pyhydroquebec/outputter.py
+++ b/pyhydroquebec/outputter.py
@@ -5,6 +5,7 @@ This module defines the different output functions:
 * influxdb
 * json
 """
+import json
 
 from pyhydroquebec.consts import (OVERVIEW_TPL,
                                   CONSUMPTION_PROFILE_TPL,
@@ -66,7 +67,27 @@ def output_influx(contract):
 #        print(msg.format(contract, data, yesterday_str))
 
 
-def output_json(data):
-    """Print data as Json."""
-    raise Exception("FIXME")
-#    print(json.dumps(data))
+def output_json(customer, show_hourly=False):
+    """Print data as a json."""
+    out = {}
+    out['overview'] = {
+        "contract_id": customer.contract_id,
+        "account_id": customer.account_id,
+        "customer_id": customer.customer_id,
+        "balance": customer.balance
+    }
+    if customer.current_period['period_total_bill']:
+        out["current_period"] = customer.current_period
+    if customer.current_annual_data:
+        out["current_annual_data"] = customer.current_annual_data
+    yesterday_date = list(customer.current_daily_data.keys())[0]
+    yesterday_data = {'date': yesterday_date}
+    yesterday_data.update(customer.current_daily_data[yesterday_date])
+    out["yesterday_data"] = yesterday_data
+    if show_hourly:
+        out["hourly_data"] = []
+        for hour, data in customer.hourly_data[yesterday_date]["hours"].items():
+            hourly_object = {"hour": hour}
+            hourly_object.update(data)
+            out["hourly_data"].append(hourly_object)
+    print(json.dumps(out))

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,70 +1,119 @@
 """Tests for output module."""
-# import re
-#
-# from pyhydroquebec.output import output_influx
-#
-#
-# def test_influx_output(capsys):
-#    """Test influx output function."""
-#
-#    data = {'310277835': {
-#               'annual_date_end': '2018-11-28',
-#               'annual_date_start': '2017-11-25',
-#               'annual_kwh_price_cent': 8.94,
-#               'annual_length': 369,
-#               'annual_mean_daily_bill': 5.05,
-#               'annual_mean_daily_consumption': 56.5,
-#               'annual_total_bill': 1863.19,
-#               'annual_total_consumption': 20835,
-#               'balance': 320.59,
-#               'period_average_temperature': 0,
-#               'period_higher_price_consumption': 0,
-#               'period_length': 2,
-#               'period_lower_price_consumption': 118,
-#               'period_mean_daily_bill': 5.33,
-#               'period_mean_daily_consumption': 59.0,
-#               'period_projection': 537.21,
-#               'period_total_bill': 10.65,
-#               'period_total_consumption': 118,
-#               'period_total_days': 65,
-#               'yesterday_average_temperature': -1,
-#               'yesterday_higher_price_consumption': 0,
-#               'yesterday_hourly_consumption': [{'high': 0,
-#                                                 'hour': '00:00:00',
-#                                                 'lower': 0.97,
-#                                                 'temp': 0,
-#                                                 'total': 0.97},
-#                                                {'high': 0,
-#                                                 'hour': '01:00:00',
-#                                                 'lower': 1.2,
-#                                                 'temp': 0,
-#                                                 'total': 1.2},
-#                                                {'high': 0,
-#                                                 'hour': '02:00:00',
-#                                                 'lower': 1.62,
-#                                                 'temp': 0,
-#                                                 'total': 1.62}],
-#               'yesterday_lower_price_consumption': 55.23,
-#               'yesterday_total_consumption': 55.23}}
-#
-#    expected = (r'''pyhydroquebec,contract=310277835 annual_date_end="2018-11-28",'''
-#                r'''annual_date_start="2017-11-25",annual_kwh_price_cent=8.94,'''
-#                r'''annual_length=369,annual_mean_daily_bill=5.05,'''
-#                r'''annual_mean_daily_consumption=56.5,annual_total_bill=1863.19,'''
-#                r'''annual_total_consumption=20835,balance=320.59,period_average_temperature=0'''
-#                r''',period_higher_price_consumption=0,period_length=2,'''
-#                r'''period_lower_price_consumption=118,period_mean_daily_bill=5.33,'''
-#                r'''period_mean_daily_consumption=59.0,period_projection=537.21,'''
-#                r'''period_total_bill=10.65,period_total_consumption=118,period_total_days=65,'''
-#                r'''yesterday_average_temperature=-1,yesterday_higher_price_consumption=0,'''
-#                r'''yesterday_lower_price_consumption=55.23,yesterday_total_consumption=55.23'''
-#                r''' \d*\n'''
-#                r'''pyhydroquebec,contract=310277835 high=0,lower=0.97,temp=0,total=0.97'''
-#                r''' \d*\n'''
-#                r'''pyhydroquebec,contract=310277835 high=0,lower=1.2,temp=0,total=1.2'''
-#                r''' \d*\n'''
-#                r'''pyhydroquebec,contract=310277835 high=0,lower=1.62,temp=0,total=1.62'''
-#                r''' \d*\n''')
-#    output_influx(data)
-#    captured = capsys.readouterr()
-#    assert re.match(expected, captured.out)
+import json
+import re
+import unittest
+
+from pyhydroquebec.outputter import output_influx, output_json
+
+
+@unittest.skip('Influx output broken.')
+def test_influx_output(capsys):
+    """Test influx output function."""
+
+    data = {'310277835': {
+               'annual_date_end': '2018-11-28',
+               'annual_date_start': '2017-11-25',
+               'annual_kwh_price_cent': 8.94,
+               'annual_length': 369,
+               'annual_mean_daily_bill': 5.05,
+               'annual_mean_daily_consumption': 56.5,
+               'annual_total_bill': 1863.19,
+               'annual_total_consumption': 20835,
+               'balance': 320.59,
+               'period_average_temperature': 0,
+               'period_higher_price_consumption': 0,
+               'period_length': 2,
+               'period_lower_price_consumption': 118,
+               'period_mean_daily_bill': 5.33,
+               'period_mean_daily_consumption': 59.0,
+               'period_projection': 537.21,
+               'period_total_bill': 10.65,
+               'period_total_consumption': 118,
+               'period_total_days': 65,
+               'yesterday_average_temperature': -1,
+               'yesterday_higher_price_consumption': 0,
+               'yesterday_hourly_consumption': [{'high': 0,
+                                                 'hour': '00:00:00',
+                                                 'lower': 0.97,
+                                                 'temp': 0,
+                                                 'total': 0.97},
+                                                {'high': 0,
+                                                 'hour': '01:00:00',
+                                                 'lower': 1.2,
+                                                 'temp': 0,
+                                                 'total': 1.2},
+                                                {'high': 0,
+                                                 'hour': '02:00:00',
+                                                 'lower': 1.62,
+                                                 'temp': 0,
+                                                 'total': 1.62}],
+               'yesterday_lower_price_consumption': 55.23,
+               'yesterday_total_consumption': 55.23}}
+
+    expected = (r'''pyhydroquebec,contract=310277835 annual_date_end="2018-11-28",'''
+                r'''annual_date_start="2017-11-25",annual_kwh_price_cent=8.94,'''
+                r'''annual_length=369,annual_mean_daily_bill=5.05,'''
+                r'''annual_mean_daily_consumption=56.5,annual_total_bill=1863.19,'''
+                r'''annual_total_consumption=20835,balance=320.59,period_average_temperature=0'''
+                r''',period_higher_price_consumption=0,period_length=2,'''
+                r'''period_lower_price_consumption=118,period_mean_daily_bill=5.33,'''
+                r'''period_mean_daily_consumption=59.0,period_projection=537.21,'''
+                r'''period_total_bill=10.65,period_total_consumption=118,period_total_days=65,'''
+                r'''yesterday_average_temperature=-1,yesterday_higher_price_consumption=0,'''
+                r'''yesterday_lower_price_consumption=55.23,yesterday_total_consumption=55.23'''
+                r''' \d*\n'''
+                r'''pyhydroquebec,contract=310277835 high=0,lower=0.97,temp=0,total=0.97'''
+                r''' \d*\n'''
+                r'''pyhydroquebec,contract=310277835 high=0,lower=1.2,temp=0,total=1.2'''
+                r''' \d*\n'''
+                r'''pyhydroquebec,contract=310277835 high=0,lower=1.62,temp=0,total=1.62'''
+                r''' \d*\n''')
+    output_influx(data)
+    captured = capsys.readouterr()
+    assert re.match(expected, captured.out)
+
+
+def test_json_output(capsys):
+    """Test json output function."""
+
+    data = {
+        "overview": {
+            "contract_id": "foo_customer",
+            "account_id": "foo_accoutn",
+            "customer_id": "foo_id",
+            "balance": "foo_balance"
+        },
+        "current_period": {
+            "period_total_bill": "foobar_total_bill", "current_period_data": "current_period_data"
+        },
+        "current_annual_data": {
+            "some_annual_data_key": "foobar_annual_data_value"
+        },
+        "yesterday_data": {
+            "date": "some_date",
+            "hour1": {
+                "foobar": "some_data"
+            }
+        }
+    }
+
+    # \n because of trailing newline in readouterr
+    expected = f'{json.dumps(data)}\n'
+
+    class MockCustomer:  # pylint: disable=too-few-public-methods
+        """Mock class for Customer."""
+        contract_id = "foo_customer"
+        account_id = "foo_accoutn"
+        customer_id = "foo_id"
+        balance = "foo_balance"
+        current_period = {
+            "period_total_bill": "foobar_total_bill", "current_period_data": "current_period_data"
+        }
+        current_annual_data = {"some_annual_data_key": "foobar_annual_data_value"}
+        current_daily_data = {"some_date": {"hour1": {"foobar": "some_data"}}}
+
+    mock_customer = MockCustomer()
+    output_json(mock_customer)
+    captured = capsys.readouterr()
+
+    assert captured.out == expected


### PR DESCRIPTION
Hey @titilambert , thanks for the project, it's pretty useful. Figure I could contribute :)

I'm not exactly sure where you wanted to go with the `--json` option, but I'm guessing that you want to emulate the text output, so here is a PR. Also, for the record, fixes #58 .

Example run.: 

```
> pyhydroquebec -H -j
2020-09-13 22:07:34,723 - WARNING - pyhydroquebec - Contract id not specified, using first available.
{"overview": {"contract_id": "312809048", "account_id": "0109436910", "customer_id": "0109436910", "balance": -116.75}, "current_period": {"period_total_bill": 15.45, "period_projection": 92.72, "period_length": 10, "period_total_days": 62, "period_mean_daily_bill": 1.55, "period_mean_daily_consumption": 15.4, "period_total_consumption": 154, "period_lower_price_consumption": 154, "period_higher_price_consumption": 0, "period_average_temperature": 16}, "current_annual_data": {"annual_mean_daily_consumption": 26.7, "annual_total_consumption": 9756, "annual_total_bill": 852.57, "annual_mean_daily_bill": 2.34, "annual_length": 365, "annual_kwh_price_cent": 8.74, "annual_date_start": "2019-09-04", "annual_date_end": "2020-09-02"}, "yesterday_data": {"date": "2020-09-12", "total_consumption": 15.94, "lower_price_consumption": 15.94, "higher_price_consumption": 0, "average_temperature": 15}, "hourly_data": [{"hour": 0, "average_temperature": 10, "lower_price_consumption": 0.14, "higher_price_consumption": 0, "total_consumption": 0.14}, {"hour": 1, "average_temperature": 9, "lower_price_consumption": 0.23, "higher_price_consumption": 0, "total_consumption": 0.23}, {"hour": 2, "average_temperature": 9, "lower_price_consumption": 0.53, "higher_price_consumption": 0, "total_consumption": 0.53}, {"hour": 3, "average_temperature": 9, "lower_price_consumption": 0.13, "higher_price_consumption": 0, "total_consumption": 0.13}, {"hour": 4, "average_temperature": 8, "lower_price_consumption": 0.24, "higher_price_consumption": 0, "total_consumption": 0.24}, {"hour": 5, "average_temperature": 8, "lower_price_consumption": 0.13, "higher_price_consumption": 0, "total_consumption": 0.13}, {"hour": 6, "average_temperature": 11, "lower_price_consumption": 0.16, "higher_price_consumption": 0, "total_consumption": 0.16}, {"hour": 7, "average_temperature": 13, "lower_price_consumption": 0.21, "higher_price_consumption": 0, "total_consumption": 0.21}, {"hour": 8, "average_temperature": 15, "lower_price_consumption": 0.58, "higher_price_consumption": 0, "total_consumption": 0.58}, {"hour": 9, "average_temperature": 15, "lower_price_consumption": 0.29, "higher_price_consumption": 0, "total_consumption": 0.29}, {"hour": 10, "average_temperature": 17, "lower_price_consumption": 0.7, "higher_price_consumption": 0, "total_consumption": 0.7}, {"hour": 11, "average_temperature": 18, "lower_price_consumption": 0.58, "higher_price_consumption": 0, "total_consumption": 0.58}, {"hour": 12, "average_temperature": 19, "lower_price_consumption": 0.89, "higher_price_consumption": 0, "total_consumption": 0.89}, {"hour": 13, "average_temperature": 19, "lower_price_consumption": 0.33, "higher_price_consumption": 0, "total_consumption": 0.33}, {"hour": 14, "average_temperature": 20, "lower_price_consumption": 0.54, "higher_price_consumption": 0, "total_consumption": 0.54}, {"hour": 15, "average_temperature": 19, "lower_price_consumption": 0.23, "higher_price_consumption": 0, "total_consumption": 0.23}, {"hour": 16, "average_temperature": 20, "lower_price_consumption": 0.21, "higher_price_consumption": 0, "total_consumption": 0.21}, {"hour": 17, "average_temperature": 19, "lower_price_consumption": 0.27, "higher_price_consumption": 0, "total_consumption": 0.27}, {"hour": 18, "average_temperature": 19, "lower_price_consumption": 2.12, "higher_price_consumption": 0, "total_consumption": 2.12}, {"hour": 19, "average_temperature": 18, "lower_price_consumption": 0.78, "higher_price_consumption": 0, "total_consumption": 0.78}, {"hour": 20, "average_temperature": 17, "lower_price_consumption": 1.95, "higher_price_consumption": 0, "total_consumption": 1.95}, {"hour": 21, "average_temperature": 16, "lower_price_consumption": 3.33, "higher_price_consumption": 0, "total_consumption": 3.33}, {"hour": 22, "average_temperature": 16, "lower_price_consumption": 0.61, "higher_price_consumption": 0, "total_consumption": 0.61}, {"hour": 23, "average_temperature": 16, "lower_price_consumption": 0.73, "higher_price_consumption": 0, "total_consumption": 0.73}]}

```

Sorry for the long line, don't think markdown supports new lines out of the box.

Let me know if you want something changed.