### PR TITLE
Add possibility to view winter dynamic tarif event messages 

### DIFF
--- a/pyhydroquebec/__main__.py
+++ b/pyhydroquebec/__main__.py
@@ -23,6 +23,7 @@ async def fetch_data(client, contract_id, fetch_hourly=False):
         if contract_id is None:
             client.logger.warn("Contract id not specified, using first available.")
 
+        await customer.fetch_common_data()
         await customer.fetch_current_period()
         await customer.fetch_annual_data()
         await customer.fetch_monthly_data()

--- a/pyhydroquebec/consts.py
+++ b/pyhydroquebec/consts.py
@@ -140,14 +140,15 @@ Contract: {0.contract_id}
 Balance: {0.balance:.2f} $
 """)
 
+# Add those 2 lines to COMMON_TPL if you need them and also uncomment them in customer.py
+#Adress Line 1: {d[adress_line_1]}
+#Adress Line 2: {d[adress_line_2]}
+
 COMMON_TPL = ("""
 Hydro Quebec common data
 ========================
 
 Tarif Code: {d[tarif_code]}
-
-Adress Line 1: {d[adress_line_1]}
-Adress Line 2: {d[adress_line_2]}
 
 Today Message: {d[today_message]}
 Tomorrow Message: {d[tomorrow_message]}

--- a/pyhydroquebec/consts.py
+++ b/pyhydroquebec/consts.py
@@ -46,6 +46,9 @@ HOURLY_DATA_URL_1 = ("{}/portail/fr/group/clientele/portrait-de-consommation/"
 HOURLY_DATA_URL_2 = ("{}/portail/fr/group/clientele/portrait-de-consommation/"
                      "resourceObtenirDonneesMeteoHoraires".format(HOST_SPRING))
 
+COMMON_DATA_URL = ("{}/portail/fr/group/clientele/portrait-de-consommation/"
+                   "resourceObtenirInfoCommunPortrait".format(HOST_SPRING))
+
 CURRENT_MAP = {'period_total_bill': {'raw_name': 'montantFacturePeriode',
                                      'unit': '$',
                                      'icon': 'mdi:currency-usd',
@@ -135,6 +138,19 @@ Contract: {0.contract_id}
 ===================
 
 Balance: {0.balance:.2f} $
+""")
+
+COMMON_TPL = ("""
+Hydro Quebec common data
+========================
+
+Tarif Code: {d[tarif_code]}
+
+Adress Line 1: {d[adress_line_1]}
+Adress Line 2: {d[adress_line_2]}
+
+Today Message: {d[today_message]}
+Tomorrow Message: {d[tomorrow_message]}
 """)
 
 CONSUMPTION_PROFILE_TPL = ("""

--- a/pyhydroquebec/customer.py
+++ b/pyhydroquebec/customer.py
@@ -318,8 +318,8 @@ class Customer():
 
         self._current_common_data = {
                 'tarif_code': json_res['results']['codeTarif'],
-                'adress_line_1': json_res['results']['adresseLieuConsoPartie1'],
-                'adress_line_2': json_res['results']['adresseLieuConsoPartie2'],
+                #'adress_line_1': json_res['results']['adresseLieuConsoPartie1'],
+                #'adress_line_2': json_res['results']['adresseLieuConsoPartie2'],
                 'today_message': json_res['results']['zoneMessageHTMLAvisAujourdhui'],
                 'tomorrow_message': json_res['results']['zoneMessageHTMLAvisDemain'],
                 }

--- a/pyhydroquebec/mqtt_daemon.py
+++ b/pyhydroquebec/mqtt_daemon.py
@@ -128,6 +128,19 @@ class MqttHydroQuebec(mqtt_hass_base.MqttDevice):
                         topic=balance_topic,
                         payload=customer.balance)
 
+                # Current Common Data
+                await customer.fetch_common_data()
+
+                for data_name, data in customer.current_common_data.items():
+                    # Publish sensor
+                    common_data_topic = self._publish_sensor(data_name,
+                                                             customer.contract_id,
+                                                             device_class=None)
+                    # Send sensor data
+                    self.mqtt_client.publish(
+                            topic=common_data_topic,
+                            payload=data)
+
                 # Current period
                 for data_name, data in CURRENT_MAP.items():
                     # Publish sensor

--- a/pyhydroquebec/outputter.py
+++ b/pyhydroquebec/outputter.py
@@ -7,7 +7,7 @@ This module defines the different output functions:
 """
 import json
 
-from pyhydroquebec.consts import (OVERVIEW_TPL,
+from pyhydroquebec.consts import (OVERVIEW_TPL, COMMON_TPL,
                                   CONSUMPTION_PROFILE_TPL,
                                   YESTERDAY_TPL, ANNUAL_TPL, HOURLY_HEADER, HOURLY_TPL)
 
@@ -15,6 +15,7 @@ from pyhydroquebec.consts import (OVERVIEW_TPL,
 def output_text(customer, show_hourly=False):
     """Format data to get a readable output."""
     print(OVERVIEW_TPL.format(customer))
+    print(COMMON_TPL.format(d=customer.current_common_data))
     if customer.current_period['period_total_bill']:
         print(CONSUMPTION_PROFILE_TPL.format(d=customer.current_period))
     if customer.current_annual_data:
@@ -76,6 +77,7 @@ def output_json(customer, show_hourly=False):
         "customer_id": customer.customer_id,
         "balance": customer.balance
     }
+    out["common_data"] = customer.current_common_data
     if customer.current_period['period_total_bill']:
         out["current_period"] = customer.current_period
     if customer.current_annual_data:


### PR DESCRIPTION
This PR enable the capability to view the message for today and tomorrow for the winter Dynamic Tarif. It give you the same message as when you log into your account . Ex.: 'le 13 février, réduisez votre consommation d’électricité de 6h à 9h.' in MQTT sensor or command line. You can also have your type of account. Ex.: D and your street address for the account (uncomment 2 files if needed).

Thanks 