### PR TITLE
remove float formating to period_projection

### DIFF
--- a/pyhydroquebec/consts.py
+++ b/pyhydroquebec/consts.py
@@ -147,7 +147,7 @@ Period mean temperate:  {d[period_average_temperature]:.1f} °C
 Period current bill
 ===================
 Total Bill:             {d[period_total_bill]:.2f} $
-Projection bill:        {d[period_projection]:.2f} $
+Projection bill:        {d[period_projection]} $
 Mean Daily Bill:        {d[period_mean_daily_bill]:.2f} $
 
 Total period consumption


### PR DESCRIPTION
Was getting an error while gathering my data:

```
raceback (most recent call last):
  File "/Users/charlesdagenais/Sites/pyhydroquebec/./env/bin/pyhydroquebec", line 33, in <module>
    sys.exit(load_entry_point('pyhydroquebec', 'console_scripts', 'pyhydroquebec')())
  File "/Users/charlesdagenais/Sites/pyhydroquebec/pyhydroquebec/__main__.py", line 168, in main
    output_text(results[0], args.hourly)
  File "/Users/charlesdagenais/Sites/pyhydroquebec/pyhydroquebec/outputter.py", line 19, in output_text
    print(CONSUMPTION_PROFILE_TPL.format(d=customer.current_period))
TypeError: unsupported format string passed to NoneType.__format__
```

because `'period_projection': None`  in `customer.current_period`
