### PR TITLE
feat: reduce image size by 100MB using multi-stage dockerbuild, introduce using a user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
 FROM python:3.7-alpine
-
 RUN apk add --no-cache gcc musl-dev
+COPY requirements.txt ./
+RUN pip install -r requirements.txt --force-reinstall --no-cache-dir  --user
+COPY . .
+RUN python setup.py install --user
+
+FROM python:3.7-alpine
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+COPY --chown=appuser:appgroup --from=0 /root/.local/ /home/appuser/.local/
 
 WORKDIR /usr/src/app
+COPY --chown=appuser:appgroup ./entrypoint.sh .
+RUN mkdir -p /usr/src/app && \
+    chown -R appuser:appgroup /home/appuser /usr/src/app
 
-COPY requirements.txt ./
-RUN pip install -r requirements.txt --force-reinstall --no-cache-dir
-
-COPY ./entrypoint.sh .
-
-COPY . .
-
-RUN ["chmod", "+x", "./entrypoint.sh"]
-
-RUN python setup.py install
-
+USER appuser
+RUN chmod +x ./entrypoint.sh
 CMD [ "./entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-
+INSTALL="/home/appuser/.local"
 # Check user and password
 if [ -z "$PYHQ_USER" ] || [ -z "$PYHQ_PASSWORD" ]  && [ "$PYHQ_OUTPUT" != "MQTT" ]
 then
@@ -41,9 +41,9 @@ then
     export CONFIG="/etc/pyhydroquebec/pyhydroquebec.yaml"
 fi
 
-if [ "$PYHQ_OUTPUT" == "MQTT" ]
+if [ "$PYHQ_OUTPUT" = "MQTT" ]
 then
-    mqtt_pyhydroquebec
+    "$INSTALL"/bin/mqtt_pyhydroquebec
 else
-    pyhydroquebec -u $PYHQ_USER -p $PYHQ_PASSWORD $PYHQ_CMD_OUTPUT $PYHQ_CMD_CONTRACT
+    "$INSTALL"/bin/pyhydroquebec -u "$PYHQ_USER" -p "$PYHQ_PASSWORD" $PYHQ_CMD_OUTPUT $PYHQ_CMD_CONTRACT
 fi


### PR DESCRIPTION
Introduce a multi-stage build - reduces size from ~160MB by ~100MB down to 60MB. 
 - use the `--user` installation which puts the installation into `$HOME/.local`.
 - change the entrypoint to reference as so

Use a user in the final container - best practices, security.
 - move from `/root/.local` to `/home/appuser/.local`

note, I've only tested `docker run --rm -it -ePYHQ_USER  -ePYHQ_PASSWORD` from the cli as I don't have a mqtt setup atm.