### PR TITLE
Todo topic : Add “planned service interruption”

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,7 @@ TODO
 ####
 
 * Add automated tests
+* Add detection for "planned service interruption"
 
 Installation
 ############


### PR DESCRIPTION
Ultimately the “planned service interruption” information (start/end date/time) can be published to mqtt.

If I could make the changes myself, I would… but http/api ain’t my area.  Hoping someone will pick this up.

Merci.